### PR TITLE
let plugins be installed from GitHub

### DIFF
--- a/server/build-plugins.js
+++ b/server/build-plugins.js
@@ -18,6 +18,15 @@ const camelize = str =>
     })
     .replace(/[^\w]/gi, '');
 
+const getPackageName = name => {
+  if (name.indexOf('/') !== -1 && name[0] !== '@') {
+    // this is a GitHub repo
+    return name.split('/')[1];
+  } else {
+    return name;
+  }
+};
+
 const prepareModules = (plugins = [], local = true) => {
   const pluginsPath = resolve(__dirname, '../webapp/plugins');
   let pluginsIndex = local
@@ -28,8 +37,9 @@ const prepareModules = (plugins = [], local = true) => {
   let installPackages = [];
 
   plugins.forEach(name => {
-    const camelized = camelize(name);
-    const modulePath = local ? `./${name}` : name;
+    const packageName = getPackageName(name);
+    const camelized = camelize(packageName);
+    const modulePath = local ? `./${packageName}` : packageName;
     if (!local) installPackages.push(name);
     importsText += `import * as ${camelized} from '${modulePath}';\n`;
     exportsText += `${camelized},`;


### PR DESCRIPTION
This installs plugins from GitHub (when they don't begin with an "@", which indicates an npm module).

The one catch is that to install a plugin from GitHub, that repo needs to be ready to install from (meaning it needs to include the "dist" folder if there is one that needs to be built). Currently in the default plugin generated by the tool, the dist folder is ignored by .gitignore. So I'd also suggest removing that line from the default (which can be done separately).